### PR TITLE
Participants can play multiple games that are different

### DIFF
--- a/experiments/from-scratch/client/intro/newPlayer_Arabic1.jsx
+++ b/experiments/from-scratch/client/intro/newPlayer_Arabic1.jsx
@@ -15,7 +15,7 @@ export default class PlayerId extends Component {
 
         const { handleNewPlayer } = this.props;
         const { id } = this.state;
-        handleNewPlayer(id);
+        handleNewPlayer(id.concat("Arabic1"));
     };
 
     // for BCS radio button

--- a/experiments/from-scratch/client/intro/newPlayer_BCS1.jsx
+++ b/experiments/from-scratch/client/intro/newPlayer_BCS1.jsx
@@ -15,7 +15,7 @@ export default class PlayerId extends Component {
 
         const { handleNewPlayer } = this.props;
         const { id } = this.state;
-        handleNewPlayer(id);
+        handleNewPlayer(idid.concat("BCS1"));
     };
 
     // for BCS radio button

--- a/experiments/from-scratch/client/intro/newPlayer_BCS2.jsx
+++ b/experiments/from-scratch/client/intro/newPlayer_BCS2.jsx
@@ -15,7 +15,7 @@ export default class PlayerId extends Component {
 
         const { handleNewPlayer } = this.props;
         const { id } = this.state;
-        handleNewPlayer(id);
+        handleNewPlayer(idid.concat("BCS2"));
     };
 
     // for BCS radio button
@@ -50,7 +50,7 @@ export default class PlayerId extends Component {
                         <p>
                           <div>
                             <br></br>Ako imate Prolific ID, unesite taj broj a <b>ne</b> vašu email adresu.
-                            <br></br>Ako vaš partner ima Prolific ID, molimo vas unesite vašu email adresu. Dobićete naknadu kroz Prolific Bonus Payment kroz konta vašeg partnera. 
+                            <br></br>Ako vaš partner ima Prolific ID, molimo vas unesite vašu email adresu. Dobićete naknadu kroz Prolific Bonus Payment kroz konta vašeg partnera.
                             <br></br>Ako ni vi ni vaš partner nemate Prolific, dobićete naknadu kroz Amazon gift karticu.
                             <br></br>Mi nudimo Amazon gift kartice za sledeće zemlje: SAD (USA), Velika Britanija (UK), Kanada, Nemačka, Italija, Francuska, Španija, Australija.
                           </div>

--- a/experiments/from-scratch/client/intro/newPlayer_BCS2Community.jsx
+++ b/experiments/from-scratch/client/intro/newPlayer_BCS2Community.jsx
@@ -15,7 +15,7 @@ export default class PlayerId extends Component {
 
         const { handleNewPlayer } = this.props;
         const { id } = this.state;
-        handleNewPlayer(id);
+        handleNewPlayer(id.concat("BCS2Community"));
     };
 
     // for BCS radio button

--- a/experiments/from-scratch/client/intro/newPlayer_BCS2Prolific.jsx
+++ b/experiments/from-scratch/client/intro/newPlayer_BCS2Prolific.jsx
@@ -15,7 +15,7 @@ export default class PlayerId extends Component {
 
         const { handleNewPlayer } = this.props;
         const { id } = this.state;
-        handleNewPlayer(id);
+        handleNewPlayer(id.concat("BCS2Prolific"));
     };
 
     // for BCS radio button
@@ -51,7 +51,7 @@ export default class PlayerId extends Component {
                           <div>
                             <br></br> Molimo vas da unesete Prolific ID ukoliko ga imate.
                             <br></br> Ukoliko niste popunili formular za prijavu na Prolific-u, molimo vas unesite vašu email adresu.
-                            <br></br> Mi ćemo poslati nadoknadu od 14 dolara (USD) preko Prolific Bonus Payment učestniku koji je registrovan na Prolific-u. Taj učesnik treba da podeli nadoknadu sa svojim suigračem (svakoj osobi po $7). Drugim rečima, suigrač koji nije registrovan na Prolific-u može svoju nadoknadu da dobije samo od svog suigrača. 
+                            <br></br> Mi ćemo poslati nadoknadu od 14 dolara (USD) preko Prolific Bonus Payment učestniku koji je registrovan na Prolific-u. Taj učesnik treba da podeli nadoknadu sa svojim suigračem (svakoj osobi po $7). Drugim rečima, suigrač koji nije registrovan na Prolific-u može svoju nadoknadu da dobije samo od svog suigrača.
                           </div>
                         </p>
 

--- a/experiments/from-scratch/client/intro/newPlayer_BCSEng1.jsx
+++ b/experiments/from-scratch/client/intro/newPlayer_BCSEng1.jsx
@@ -15,7 +15,7 @@ export default class PlayerId extends Component {
 
         const { handleNewPlayer } = this.props;
         const { id } = this.state;
-        handleNewPlayer(id);
+        handleNewPlayer(id.concat("BCSEng1"));
     };
 
     // for BCS radio button

--- a/experiments/from-scratch/client/intro/newPlayer_BCSEng2.jsx
+++ b/experiments/from-scratch/client/intro/newPlayer_BCSEng2.jsx
@@ -15,7 +15,7 @@ export default class PlayerId extends Component {
 
         const { handleNewPlayer } = this.props;
         const { id } = this.state;
-        handleNewPlayer(id);
+        handleNewPlayer(id.concat("BCSEng2"));
     };
 
     // for BCS radio button
@@ -53,7 +53,7 @@ export default class PlayerId extends Component {
                             <br></br>If you have a Prolific ID, please enter the ID and <b>not</b> your email address.
                             <br></br>If you are a partner of someone recruited via prolific, please provide your email address (you will not receive any emails from us).
                             <br></br> A compensation of $14 (USD) is provided via a prolific bonus payment to the partner who was recruited via prolific. It is up to that person to split the compensation equally between both partners ($7 each). In other words, if you did not complete the prolific pre-registration, you will receive your compensation from your partner (and not directly from us).
-                          </div> 
+                          </div>
                         </p>
 
                         <p

--- a/experiments/from-scratch/client/intro/newPlayer_BCSEng2Pilot.jsx
+++ b/experiments/from-scratch/client/intro/newPlayer_BCSEng2Pilot.jsx
@@ -15,7 +15,7 @@ export default class PlayerId extends Component {
 
         const { handleNewPlayer } = this.props;
         const { id } = this.state;
-        handleNewPlayer(id);
+        handleNewPlayer(id.concat("BCSEng2Pilot"));
     };
 
     // for BCS radio button

--- a/experiments/from-scratch/client/intro/newPlayer_Spanish1.jsx
+++ b/experiments/from-scratch/client/intro/newPlayer_Spanish1.jsx
@@ -15,7 +15,7 @@ export default class PlayerId extends Component {
 
         const { handleNewPlayer } = this.props;
         const { id } = this.state;
-        handleNewPlayer(id);
+        handleNewPlayer(id.concat("Spanish1"));
     };
 
     // for BCS radio button


### PR DESCRIPTION
Appended string to each player id that specifies the batchgroupname. Therefore, Empirica will now log not just participants email adresses (e.g. stefan@gmail.com) but rather a unique pair of email and game the person logged into (e.g. stefan@gmail.comEnglish1). The result of this is people with the same email or prolific ID can play different games on our platform but still be prevented from playing the same game twice. This does not work for the default game which is played if batchGroupName URL parameter is not specified (i.e. Degen et al. 2020)